### PR TITLE
Add useful metadata to field types / generated classes

### DIFF
--- a/generator/sbe_class_generator.py
+++ b/generator/sbe_class_generator.py
@@ -116,19 +116,20 @@ def main(argv=None):
 
         # Update the groups
         for msg_groups in message_class.groups:
-            iter_description = {'name': msg_groups.name,
+            group_description = {'name': msg_groups.name,
                                 'original_name': msg_groups.original_name,
+                                'id': msg_groups.id,
                                 'type': type(msg_groups).__name__,
                                 'dimension_size': msg_groups.dimension_size}
 
             block_length_field = msg_groups.block_length_field
-            iter_description['block_length_field'] = {'name': block_length_field.name,
+            group_description['block_length_field'] = {'name': block_length_field.name,
                                                       'original_name': block_length_field.original_name,
                                                       'type': type(block_length_field).__name__,
                                                       'kwargs': block_length_field.__dict__}
 
             num_in_group_field = msg_groups.num_in_group_field
-            iter_description['num_in_group_field'] = {'name': num_in_group_field.name,
+            group_description['num_in_group_field'] = {'name': num_in_group_field.name,
                                                       'original_name': num_in_group_field.original_name,
                                                       'type': type(num_in_group_field).__name__,
                                                       'kwargs': num_in_group_field.__dict__}
@@ -137,8 +138,8 @@ def main(argv=None):
             for field in msg_groups.fields:
                 field_description = build_field_description(field)
                 group_fields.append(field_description)
-            iter_description['fields'] = group_fields
-            message_groups.append(iter_description)
+            group_description['fields'] = group_fields
+            message_groups.append(group_description)
 
         message_descriptions.append(message_description)
 

--- a/generator/sbe_class_generator.py
+++ b/generator/sbe_class_generator.py
@@ -117,16 +117,19 @@ def main(argv=None):
         # Update the groups
         for msg_groups in message_class.groups:
             iter_description = {'name': msg_groups.name,
+                                'original_name': msg_groups.original_name,
                                 'type': type(msg_groups).__name__,
                                 'dimension_size': msg_groups.dimension_size}
 
             block_length_field = msg_groups.block_length_field
             iter_description['block_length_field'] = {'name': block_length_field.name,
+                                                      'original_name': block_length_field.original_name,
                                                       'type': type(block_length_field).__name__,
                                                       'kwargs': block_length_field.__dict__}
 
             num_in_group_field = msg_groups.num_in_group_field
             iter_description['num_in_group_field'] = {'name': num_in_group_field.name,
+                                                      'original_name': num_in_group_field.original_name,
                                                       'type': type(num_in_group_field).__name__,
                                                       'kwargs': num_in_group_field.__dict__}
 

--- a/generator/sbe_message.tmpl
+++ b/generator/sbe_message.tmpl
@@ -53,6 +53,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            field_offset=${field.kwargs.field_offset},
                                            float_value=${field.kwargs.float_value},
                                            description='''${field.kwargs.description}''',
+                                           semantic_type='${field.kwargs.semantic_type}',
                                            parts=[
                                                %for part in field.kwargs.parts:
                                                ${part.type}(${str(part.kwargs)}),
@@ -66,6 +67,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            description='''${field.kwargs.description}''',
                                            field_offset=${field.kwargs.field_offset},
                                            field_length=${field.kwargs.field_length},
+                                           semantic_type='${field.kwargs.semantic_type}',
                                            enum_values=[
                                                %for enum_val in field.kwargs.enum_values:
                                                ${enum_val.__dict__},
@@ -79,6 +81,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            description='''${field.kwargs.description}''',
                                            field_offset=${field.kwargs.field_offset},
                                            field_length=${field.kwargs.field_length},
+                                           semantic_type='${field.kwargs.semantic_type}',
                                            choices=[
                                             %for choice_val in field.kwargs.choices:
                                             ${choice_val.__dict__},
@@ -117,6 +120,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                             field_offset=${field.kwargs.field_offset},
                                                             description='''${field.kwargs.description}''',
                                                             float_value=${field.kwargs.float_value},
+                                                            semantic_type='${field.kwargs.semantic_type}',
                                                             parts=[
                                                                 %for part in field.kwargs.parts:
                                                                 ${part.type}(${str(part.kwargs)}),
@@ -130,6 +134,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                              description='''${field.kwargs.description}''',
                                                              field_offset=${field.kwargs.field_offset},
                                                              field_length=${field.kwargs.field_length},
+                                                             semantic_type='${field.kwargs.semantic_type}',
                                                              enum_values=[
                                                                  %for enum_val in field.kwargs.enum_values:
                                                                  ${enum_val.__dict__},
@@ -143,6 +148,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                              description='''${field.kwargs.description}''',
                                                              field_offset=${field.kwargs.field_offset},
                                                              field_length=${field.kwargs.field_length},
+                                                             semantic_type='${field.kwargs.semantic_type}',
                                                              choices=[
                                                                  %for choice_val in field.kwargs.choices:
                                                                  ${choice_val.__dict__},

--- a/generator/sbe_message.tmpl
+++ b/generator/sbe_message.tmpl
@@ -47,6 +47,8 @@ class ${message_def.name}(${message_def.base_classes}):
         %for field in message_def.fields:
         %if field.type == 'CompositeMessageField':
         self.${field.name} = ${field.type}(name='${field.name}',
+                                           original_name='${field.kwargs.original_name}',
+                                           id=${field.kwargs.id},
                                            field_length=${field.kwargs.field_length},
                                            field_offset=${field.kwargs.field_offset},
                                            float_value=${field.kwargs.float_value},
@@ -58,6 +60,8 @@ class ${message_def.name}(${message_def.base_classes}):
                                            ])
         %elif field.type == 'EnumMessageField':
         self.${field.name} = ${field.type}(name='${field.name}',
+                                           original_name='${field.kwargs.original_name}',
+                                           id=${field.kwargs.id},
                                            unpack_fmt='${field.kwargs.unpack_fmt}',
                                            description='''${field.kwargs.description}''',
                                            field_offset=${field.kwargs.field_offset},
@@ -69,6 +73,8 @@ class ${message_def.name}(${message_def.base_classes}):
                                            ])
         %elif field.type == 'SetMessageField':
         self.${field.name} = ${field.type}(name='${field.name}',
+                                           original_name='${field.kwargs.original_name}',
+                                           id=${field.kwargs.id},
                                            unpack_fmt='${field.kwargs.unpack_fmt}',
                                            description='''${field.kwargs.description}''',
                                            field_offset=${field.kwargs.field_offset},
@@ -96,6 +102,7 @@ class ${message_def.name}(${message_def.base_classes}):
         %if message_def.groups:
         %for group in message_def.groups:
         self.${group.name} = ${group.type}(name='${group.name}',
+                                           original_name='${group.original_name}',
                                            dimension_size=${group.dimension_size},
                                            block_length_field=${group.block_length_field.type}(${str(group.block_length_field.kwargs)}),
                                            num_in_group_field=${group.num_in_group_field.type}(${str(group.num_in_group_field.kwargs)}),
@@ -103,6 +110,8 @@ class ${message_def.name}(${message_def.base_classes}):
                                                %for field in group.fields:
                                                %if field.type == 'CompositeMessageField':
                                                ${field.type}(name='${field.name}',
+                                                            original_name='${field.kwargs.original_name}',
+                                                            id=${field.kwargs.id},
                                                             field_length=${field.kwargs.field_length},
                                                             field_offset=${field.kwargs.field_offset},
                                                             description='''${field.kwargs.description}''',
@@ -114,6 +123,8 @@ class ${message_def.name}(${message_def.base_classes}):
                                                             ]),
                                                %elif field.type == 'EnumMessageField':
                                                ${field.type}(name='${field.name}',
+                                                             original_name='${field.kwargs.original_name}',
+                                                             id=${field.kwargs.id},
                                                              unpack_fmt='${field.kwargs.unpack_fmt}',
                                                              description='''${field.kwargs.description}''',
                                                              field_offset=${field.kwargs.field_offset},
@@ -125,6 +136,8 @@ class ${message_def.name}(${message_def.base_classes}):
                                                              ]),
                                                %elif field.type == 'SetMessageField':
                                                ${field.type}(name='${field.name}',
+                                                             original_name='${field.kwargs.original_name}',
+                                                             id=${field.kwargs.id},
                                                              unpack_fmt='${field.kwargs.unpack_fmt}',
                                                              description='''${field.kwargs.description}''',
                                                              field_offset=${field.kwargs.field_offset},

--- a/generator/sbe_message.tmpl
+++ b/generator/sbe_message.tmpl
@@ -103,6 +103,7 @@ class ${message_def.name}(${message_def.base_classes}):
         %for group in message_def.groups:
         self.${group.name} = ${group.type}(name='${group.name}',
                                            original_name='${group.original_name}',
+                                           id=${group.id},
                                            dimension_size=${group.dimension_size},
                                            block_length_field=${group.block_length_field.type}(${str(group.block_length_field.kwargs)}),
                                            num_in_group_field=${group.num_in_group_field.type}(${str(group.num_in_group_field.kwargs)}),

--- a/sbedecoder/__init__.py
+++ b/sbedecoder/__init__.py
@@ -1,4 +1,3 @@
 from schema import SBESchema
 from message import SBEMessageFactory
 from parser import SBEParser
-from generated import *

--- a/sbedecoder/message.py
+++ b/sbedecoder/message.py
@@ -217,13 +217,14 @@ class SBERepeatingGroup:
             yield group
 
 class SBERepeatingGroupContainer(object):
-    def __init__(self, name=None, original_name=None, block_length_field=None, num_in_group_field=None, dimension_size=None, fields=None, groups=None):
+    def __init__(self, name=None, original_name=None, id=None, block_length_field=None, num_in_group_field=None, dimension_size=None, fields=None, groups=None):
         self.msg_buffer = None
         self.msg_offset = 0
         self.group_start_offset = 0
 
         self.name = name
         self.original_name = original_name
+        self.id = id
         self.block_length_field = block_length_field
         self.num_in_group_field = num_in_group_field
 

--- a/sbedecoder/message.py
+++ b/sbedecoder/message.py
@@ -38,7 +38,8 @@ class TypeMessageField(SBEMessageField):
                  id=None, description=None,
                  unpack_fmt=None, field_offset=None,
                  field_length=None, optional=False,
-                 null_value=None, constant=None, is_string_type=False):
+                 null_value=None, constant=None, is_string_type=False,
+                 semantic_type=None):
         super(SBEMessageField, self).__init__()
         self.name = name
         self.original_name = original_name
@@ -51,6 +52,7 @@ class TypeMessageField(SBEMessageField):
         self.null_value = null_value
         self.constant = constant
         self.is_string_type = is_string_type
+        self.semantic_type = semantic_type
 
     @property
     def value(self):
@@ -81,7 +83,7 @@ class TypeMessageField(SBEMessageField):
 
 class SetMessageField(SBEMessageField):
     def __init__(self, name=None, original_name=None, id=None, description=None, unpack_fmt=None, field_offset=None,
-                 choices=None, field_length=None):
+                 choices=None, field_length=None, semantic_type=None):
         super(SBEMessageField, self).__init__()
         self.name = name
         self.original_name = original_name
@@ -92,6 +94,7 @@ class SetMessageField(SBEMessageField):
         self.choices = choices
         self.field_length = field_length
         self.text_to_name = dict((int(x['text']), x['name']) for x in choices)
+        self.semantic_type = semantic_type
 
     @property
     def value(self):
@@ -116,7 +119,7 @@ class SetMessageField(SBEMessageField):
 
 class EnumMessageField(SBEMessageField):
     def __init__(self, name=None, original_name=None, id=None, description=None, unpack_fmt=None, field_offset=None,
-                 enum_values=None, field_length=None):
+                 enum_values=None, field_length=None, semantic_type=None):
         super(SBEMessageField, self).__init__()
         self.name = name
         self.original_name = original_name
@@ -127,6 +130,7 @@ class EnumMessageField(SBEMessageField):
         self.enum_values = enum_values
         self.field_length = field_length
         self.text_to_enum_value = dict((x['text'], x['description']) for x in enum_values)
+        self.semantic_type = semantic_type
 
     @property
     def value(self):
@@ -143,7 +147,7 @@ class EnumMessageField(SBEMessageField):
 
 class CompositeMessageField(SBEMessageField):
     def __init__(self, name=None, original_name=None, id=None, description=None, field_offset=None, field_length=None,
-                 parts=None, float_value=False):
+                 parts=None, float_value=False, semantic_type=None):
         super(SBEMessageField, self).__init__()
         self.name = name
         self.original_name = original_name
@@ -153,6 +157,7 @@ class CompositeMessageField(SBEMessageField):
         self.field_length = field_length
         self.parts = parts
         self.float_value = float_value
+        self.semantic_type = semantic_type
 
         # Map the parts
         for part in self.parts:

--- a/sbedecoder/message.py
+++ b/sbedecoder/message.py
@@ -5,6 +5,8 @@ import math
 class SBEMessageField(object):
     def __init__(self):
         self.name = None
+        self.original_name = None
+        self.id = None
         self.description = None
         self.msg_buffer = None
         self.msg_offset = None
@@ -32,12 +34,14 @@ class SBEMessageField(object):
 
 
 class TypeMessageField(SBEMessageField):
-    def __init__(self, name=None, id=None, description=None,
+    def __init__(self, name=None, original_name=None,
+                 id=None, description=None,
                  unpack_fmt=None, field_offset=None,
                  field_length=None, optional=False,
                  null_value=None, constant=None, is_string_type=False):
         super(SBEMessageField, self).__init__()
         self.name = name
+        self.original_name = original_name
         self.id = id
         self.description = description
         self.unpack_fmt = unpack_fmt
@@ -76,10 +80,12 @@ class TypeMessageField(SBEMessageField):
 
 
 class SetMessageField(SBEMessageField):
-    def __init__(self, name=None, description=None, unpack_fmt=None, field_offset=None,
+    def __init__(self, name=None, original_name=None, id=None, description=None, unpack_fmt=None, field_offset=None,
                  choices=None, field_length=None):
         super(SBEMessageField, self).__init__()
         self.name = name
+        self.original_name = original_name
+        self.id = id
         self.description = description
         self.unpack_fmt = unpack_fmt
         self.field_offset = field_offset
@@ -109,10 +115,12 @@ class SetMessageField(SBEMessageField):
 
 
 class EnumMessageField(SBEMessageField):
-    def __init__(self, name=None, description=None, unpack_fmt=None, field_offset=None,
+    def __init__(self, name=None, original_name=None, id=None, description=None, unpack_fmt=None, field_offset=None,
                  enum_values=None, field_length=None):
         super(SBEMessageField, self).__init__()
         self.name = name
+        self.original_name = original_name
+        self.id = id
         self.description = description
         self.unpack_fmt = unpack_fmt
         self.field_offset = field_offset
@@ -134,10 +142,12 @@ class EnumMessageField(SBEMessageField):
 
 
 class CompositeMessageField(SBEMessageField):
-    def __init__(self, name=None, description=None, field_offset=None, field_length=None,
+    def __init__(self, name=None, original_name=None, id=None, description=None, field_offset=None, field_length=None,
                  parts=None, float_value=False):
         super(SBEMessageField, self).__init__()
         self.name = name
+        self.original_name = original_name
+        self.id = id
         self.description = description
         self.field_offset = field_offset
         self.field_length = field_length
@@ -177,13 +187,14 @@ class CompositeMessageField(SBEMessageField):
 
 
 class SBERepeatingGroup:
-    def __init__(self, msg_buffer, msg_offset, relative_offset, name, fields):
+    def __init__(self, msg_buffer, msg_offset, relative_offset, name, original_name, fields):
         self.msg_buffer = msg_buffer
         self.msg_offset = msg_offset
         self.relative_offset = relative_offset
         self.fields = fields
         self._groups = []
         self.name = name
+        self.original_name = original_name
 
         for field in fields:
             setattr(self, field.name, field)
@@ -206,12 +217,13 @@ class SBERepeatingGroup:
             yield group
 
 class SBERepeatingGroupContainer(object):
-    def __init__(self, name=None, block_length_field=None, num_in_group_field=None, dimension_size=None, fields=None, groups=None):
+    def __init__(self, name=None, original_name=None, block_length_field=None, num_in_group_field=None, dimension_size=None, fields=None, groups=None):
         self.msg_buffer = None
         self.msg_offset = 0
         self.group_start_offset = 0
 
         self.name = name
+        self.original_name = original_name
         self.block_length_field = block_length_field
         self.num_in_group_field = num_in_group_field
 
@@ -245,7 +257,7 @@ class SBERepeatingGroupContainer(object):
         repeated_group_offset = group_start_offset + self.dimension_size
         nested_groups_length = 0
         for i in range(num_groups):
-            repeated_group = SBERepeatingGroup(msg_buffer, msg_offset, repeated_group_offset + nested_groups_length, self.name, self.fields)
+            repeated_group = SBERepeatingGroup(msg_buffer, msg_offset, repeated_group_offset + nested_groups_length, self.name, self.original_name, self.fields)
             self._repeating_groups.append(repeated_group)
             repeated_group_offset += block_length
             # now account for any nested groups

--- a/sbedecoder/schema.py
+++ b/sbedecoder/schema.py
@@ -334,6 +334,7 @@ class SBESchema(object):
 
             group_field_offset = 0
             repeating_group = SBERepeatingGroupContainer(name=group_name, original_name=group_original_name,
+                                                         id=int(group_type['id']),
                                                          block_length_field=block_length_field,
                                                          num_in_group_field=num_in_group_field,
                                                          dimension_size=block_field_offset)

--- a/sbedecoder/schema.py
+++ b/sbedecoder/schema.py
@@ -94,7 +94,7 @@ class SBESchema(object):
         field_description = field_definition['description']
         field_type = self.type_map[field_definition['type']]
         field_type_type = field_type['type']
-        field_semantic_type = field_type.get('semantic_type', None)
+        field_semantic_type = field_definition.get('semantic_type', None)
         is_string_type = (field_semantic_type == 'String')
 
         message_field = None
@@ -141,7 +141,8 @@ class SBESchema(object):
                                              unpack_fmt=unpack_fmt, field_offset=field_offset,
                                              field_length=field_length, null_value=null_value,
                                              constant=constant, optional=optional,
-                                             is_string_type=is_string_type)
+                                             is_string_type=is_string_type,
+                                             semantic_type=field_semantic_type)
         elif field_type_type == 'enum':
             encoding_type = field_type['encoding_type']
             encoding_type_type = self.type_map[encoding_type]
@@ -172,7 +173,8 @@ class SBESchema(object):
                                              unpack_fmt=unpack_fmt,
                                              field_offset=field_offset,
                                              enum_values=enum_values,
-                                             field_length=field_length)
+                                             field_length=field_length,
+                                             semantic_type=field_semantic_type)
         elif field_type_type == 'set':
             encoding_type = field_type['encoding_type']
             encoding_type_type = self.type_map[encoding_type]
@@ -198,7 +200,8 @@ class SBESchema(object):
             choice_values = field_type['children']
             message_field = SetMessageField(name=field_name, original_name=field_original_name,
                                             id=field_id, description=field_description, unpack_fmt=unpack_fmt,
-                                            field_offset=field_offset, choices=choice_values, field_length=field_length)
+                                            field_offset=field_offset, choices=choice_values, field_length=field_length,
+                                            semantic_type=field_semantic_type)
         elif field_type_type == 'composite':
             composite_parts = []
 
@@ -239,7 +242,7 @@ class SBESchema(object):
                                                    unpack_fmt=unpack_fmt, field_offset=field_offset,
                                                    field_length=primitive_type_size,
                                                    null_value=null_value, constant=constant,
-                                                   optional=optional)
+                                                   optional=optional, semantic_type=field_semantic_type)
                 field_offset += primitive_type_size
                 field_length += primitive_type_size
                 composite_parts.append(composite_field)
@@ -248,7 +251,7 @@ class SBESchema(object):
                                                   id=field_id, description=field_description,
                                                   field_offset=field_offset, field_length=field_length,
                                                   parts=composite_parts,
-                                                  float_value=float_composite)
+                                                  float_value=float_composite, semantic_type=field_semantic_type)
         return message_field
 
     def get_message_type(self, template_id):
@@ -317,7 +320,8 @@ class SBESchema(object):
                                                           description=child['name'],
                                                           unpack_fmt=endian + primitive_type_fmt,
                                                           field_offset=block_field_offset,
-                                                          field_length=primitive_type_size)
+                                                          field_length=primitive_type_size,
+                                                          semantic_type=child.get('semantic_type'))
                     block_field_offset += primitive_type_size
                 elif child['name'] == 'numInGroup':
                     primitive_type = child['primitive_type']
@@ -329,7 +333,8 @@ class SBESchema(object):
                                                           description=child['name'],
                                                           unpack_fmt=endian + primitive_type_fmt,
                                                           field_offset=block_field_offset,
-                                                          field_length=primitive_type_size)
+                                                          field_length=primitive_type_size,
+                                                          semantic_type=child.get('semantic_type'))
                     block_field_offset += primitive_type_size
 
             group_field_offset = 0


### PR DESCRIPTION
I wanted the name in its original form in the schema; so I added
it alongside the existing name field.  Also put 'id' in some places
I should've on previous PR.

The field id is now working for composite, enum, and set
fields.

'original_name' has been added to preserve the name before
being converted to underscores