### PR TITLE
Fix for string types with semanticType != 'String'

### DIFF
--- a/sbedecoder/schema.py
+++ b/sbedecoder/schema.py
@@ -106,18 +106,17 @@ class SBESchema(object):
 
             primitive_type_fmt, primitive_type_size = self.primitive_type_map[field_type['primitive_type']]
 
-            unpack_fmt = endian
             field_length = field_type.get('length', None)
             if field_length is not None:
                 field_length = int(field_length)
-                if is_string_type:
-                    unpack_fmt += '%ss' % (str(field_length), )
+                if is_string_type or (primitive_type_fmt == 'c' and field_length > 1):
+                    unpack_fmt = '%ds' % field_length
                 else:
-                    unpack_fmt += '%s%s' % (str(field_length), primitive_type_fmt)
+                    unpack_fmt = '%s%s%s' % (endian, str(field_length), primitive_type_fmt)
             else:
                 # Field length is just the primitive type length
                 field_length = primitive_type_size
-                unpack_fmt += primitive_type_fmt
+                unpack_fmt = '%s%s' % (endian, primitive_type_fmt)
 
             constant = None
             optional = False


### PR DESCRIPTION
With 'SecurityExchange' as an example, the unpack_fmt was
being computed as '<4c', and what should've been 'XCME' came
out as 'X'.  It seems that python doesn't interpret the length
before the 'c'; so it's the same as '<c' (the endian is superfluous).

I put in a fix for type 'char' fields with length > 1 to have
a unpack_fmt of (e.g.) '4s' (no endian, either).