### PR TITLE
Add property 'enumerant' to EnumMessageField for short enum value

### DIFF
--- a/sbedecoder/message.py
+++ b/sbedecoder/message.py
@@ -129,20 +129,28 @@ class EnumMessageField(SBEMessageField):
         self.field_offset = field_offset
         self.enum_values = enum_values
         self.field_length = field_length
-        self.text_to_enum_value = dict((x['text'], x['description']) for x in enum_values)
+        self.text_to_enum_description = dict((x['text'], x['description']) for x in enum_values)
+        self.text_to_enumerant = dict((x['text'], x['name']) for x in enum_values) # shorter repr of value
         self.semantic_type = semantic_type
 
     @property
     def value(self):
         _raw_value = self.raw_value
-        _value = self.text_to_enum_value.get(str(_raw_value), None)
+        _value = self.text_to_enum_description.get(str(_raw_value), None)
         return _value
+
+    @property
+    def enumerant(self):
+        _raw_value = self.raw_value
+        _enumerant = self.text_to_enumerant.get(str(_raw_value), None)
+        return _enumerant
 
     @property
     def raw_value(self):
         _raw_value = unpack_from(self.unpack_fmt, self.msg_buffer,
                                  self.msg_offset + self.relative_offset + self.field_offset)[0]
         return _raw_value
+
 
 
 class CompositeMessageField(SBEMessageField):

--- a/tests/test_sbe_parser.py
+++ b/tests/test_sbe_parser.py
@@ -57,10 +57,13 @@ class TestSBEParserLibrary:
         assert_equals(17389, recorded_message.trade_date.value)
         assert_equals(1502401500001346819, recorded_message.transact_time.value)
         assert_equals('Reset Statistics', recorded_message.security_trading_event.value)
+        assert_equals('ResetStatistics', recorded_message.security_trading_event.enumerant)
         assert_equals('Pre Open', recorded_message.security_trading_status.value)
+        assert_equals('PreOpen', recorded_message.security_trading_status.enumerant)
         assert_equals('ES', recorded_message.security_group.value)
         assert_equals('', recorded_message.asset.value)
         assert_equals('Group Schedule', recorded_message.halt_reason.value)
+        assert_equals('GroupSchedule', recorded_message.halt_reason.enumerant)
         assert_equals(None, recorded_message.security_id.value)
 
     def test_security_status(self):


### PR DESCRIPTION
If you want the enum name and not the description from a message,
you can now use the enumerant property instead of the value property.

`value` is left unchanged.

also added some test assertions