### PR TITLE
Support SBE "sinceVersion"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ data (buffer, str, bytearay, etc):
     for message in message_parser.parse(data, offset=offset):
         process(message)
 
+Note: Unless using code generation, you cannot store the messages for later processing.
+You must process the messages on each iteration, because the messages re-use instances of
+field objects, wrapping them around new values.
+
 A parsed message is represented as an instance of
 the SBEMessage() class.  SBEMessages are comprised of zero or more sbedecoder.message.SBEField() instances and 
 zero or more sbedecoder.message.SBERepeatingGroup() instances. An SBEField() object can be one of a primitive 
@@ -78,6 +82,13 @@ mdp_book_builder.py serves as an example of using the sbedecoder package to buil
 For help with using mdp_book_builder.py:
 
     mdp_book_builder.py --help
+
+Versioning
+----------
+
+sbedecoder supports the `sinceVersion` attribute of fields, enumerants, groups, ..., etc, and so it can
+decode older (e.g. archived) binary data so long as the schema has evolved correctly to maintain support
+for the old format
 
 Performance
 -----------

--- a/generator/sbe_class_generator.py
+++ b/generator/sbe_class_generator.py
@@ -115,27 +115,28 @@ def main(argv=None):
             message_fields.append(field_description)
 
         # Update the groups
-        for msg_groups in message_class.groups:
-            group_description = {'name': msg_groups.name,
-                                'original_name': msg_groups.original_name,
-                                'id': msg_groups.id,
-                                'type': type(msg_groups).__name__,
-                                'dimension_size': msg_groups.dimension_size}
+        for repeating_group in message_class.groups:
+            group_description = {'name': repeating_group.name,
+                                'original_name': repeating_group.original_name,
+                                'id': repeating_group.id,
+                                'type': type(repeating_group).__name__,
+                                'dimension_size': repeating_group.dimension_size,
+                                'since_version': repeating_group.since_version}
 
-            block_length_field = msg_groups.block_length_field
+            block_length_field = repeating_group.block_length_field
             group_description['block_length_field'] = {'name': block_length_field.name,
                                                       'original_name': block_length_field.original_name,
                                                       'type': type(block_length_field).__name__,
                                                       'kwargs': block_length_field.__dict__}
 
-            num_in_group_field = msg_groups.num_in_group_field
+            num_in_group_field = repeating_group.num_in_group_field
             group_description['num_in_group_field'] = {'name': num_in_group_field.name,
                                                       'original_name': num_in_group_field.original_name,
                                                       'type': type(num_in_group_field).__name__,
                                                       'kwargs': num_in_group_field.__dict__}
 
             group_fields = []
-            for field in msg_groups.fields:
+            for field in repeating_group.fields:
                 field_description = build_field_description(field)
                 group_fields.append(field_description)
             group_description['fields'] = group_fields

--- a/generator/sbe_message.tmpl
+++ b/generator/sbe_message.tmpl
@@ -54,6 +54,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            float_value=${field.kwargs.float_value},
                                            description='''${field.kwargs.description}''',
                                            semantic_type='${field.kwargs.semantic_type}',
+                                           since_version=${field.kwargs.since_version},
                                            parts=[
                                                %for part in field.kwargs.parts:
                                                ${part.type}(${str(part.kwargs)}),
@@ -68,6 +69,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            field_offset=${field.kwargs.field_offset},
                                            field_length=${field.kwargs.field_length},
                                            semantic_type='${field.kwargs.semantic_type}',
+                                           since_version=${field.kwargs.since_version},
                                            enum_values=[
                                                %for enum_val in field.kwargs.enum_values:
                                                ${enum_val.__dict__},
@@ -82,6 +84,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            field_offset=${field.kwargs.field_offset},
                                            field_length=${field.kwargs.field_length},
                                            semantic_type='${field.kwargs.semantic_type}',
+                                           since_version=${field.kwargs.since_version},
                                            choices=[
                                             %for choice_val in field.kwargs.choices:
                                             ${choice_val.__dict__},
@@ -110,6 +113,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                            dimension_size=${group.dimension_size},
                                            block_length_field=${group.block_length_field.type}(${str(group.block_length_field.kwargs)}),
                                            num_in_group_field=${group.num_in_group_field.type}(${str(group.num_in_group_field.kwargs)}),
+                                           since_version=${group.since_version},
                                            fields=[
                                                %for field in group.fields:
                                                %if field.type == 'CompositeMessageField':
@@ -121,6 +125,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                             description='''${field.kwargs.description}''',
                                                             float_value=${field.kwargs.float_value},
                                                             semantic_type='${field.kwargs.semantic_type}',
+                                                            since_version=${field.kwargs.since_version},
                                                             parts=[
                                                                 %for part in field.kwargs.parts:
                                                                 ${part.type}(${str(part.kwargs)}),
@@ -135,6 +140,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                              field_offset=${field.kwargs.field_offset},
                                                              field_length=${field.kwargs.field_length},
                                                              semantic_type='${field.kwargs.semantic_type}',
+                                                             since_version=${field.kwargs.since_version},
                                                              enum_values=[
                                                                  %for enum_val in field.kwargs.enum_values:
                                                                  ${enum_val.__dict__},
@@ -149,6 +155,7 @@ class ${message_def.name}(${message_def.base_classes}):
                                                              field_offset=${field.kwargs.field_offset},
                                                              field_length=${field.kwargs.field_length},
                                                              semantic_type='${field.kwargs.semantic_type}',
+                                                             since_version=${field.kwargs.since_version},
                                                              choices=[
                                                                  %for choice_val in field.kwargs.choices:
                                                                  ${choice_val.__dict__},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="sbedecoder",
-    version="0.1",
+    version="0.1.1",
     author="TradeForecaster Global Markets, LLC",
     author_email="github@tradeforecaster.com",
     description=("Simple Bianry Encoding (SBE) decoder (handles CME MDP3 messages)"),


### PR DESCRIPTION
Adding `sinceVersion` in groups, fields, enums, ..., etc.

You can check the `sinceVersion` in the field metadata against `SBEMessage.version`
at decode-time, and skip over fields that won't be there.

Also updated your `setup.py` to increment the version (of this software) to `0.1.1`