### PR TITLE
Add version support and pretty-printing to mdp_decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ MDP 3.0 (MDP3) messages from a pcap file.  For help with using mdp_decoder.py:
 An SBE template for CME Group MDP 3.0 market data can be found at 
 ftp://ftp.cmegroup.com/SBEFix/Production/Templates/templates_FixBinary.xml
 
-Example, output:
+Example output:
 
     :packet - timestamp: 2015-06-25 09:45:01.924492 sequence_number: 93696727 sending_time: 1435243501924423666 
     ::MDIncrementalRefreshVolume -  transact_time: 1435243501923350056 match_event_indicator: LastVolumeMsg (2)
@@ -73,6 +73,40 @@ Example, output:
     :::no_md_entries - num_groups: 2
     ::::md_entry_px: 18792.0 ({'mantissa': 187920000000, 'exponent': -7}) md_entry_size: 1 security_id: 559884 rpt_seq: 2666380 number_of_orders: 1 md_price_level: 1 md_update_action: Delete (2) md_entry_type: Bid (0) 
     ::::md_entry_px: 18746.0 ({'mantissa': 187460000000, 'exponent': -7}) md_entry_size: 6 security_id: 559884 rpt_seq: 2666381 number_of_orders: 1 md_price_level: 10 md_update_action: New (0) md_entry_type: Bid (0) 
+
+Example output (with `--pretty`):
+
+
+```
+packet - timestamp: 2016-03-10 15:33:21.301819 sequence_number: 76643046 sending_time: 1454679022595400091
+    Message 1 of 2: TID 32 (MDIncrementalRefreshBook) v6
+        TransactTime (60): 02/05/2016 07:30:22.595256135 (1454679022595256135)
+        MatchEventIndicator (5799): LastQuoteMsg
+        NoMDEntries (268): 1
+        Entry 1
+            MDEntryPx (270): 98890000000 (9889.0)
+            MDEntrySize (271): 296
+            SecurityID (48): 807004
+            RptSeq (83): 14273794
+            NumberOfOrders (346): 16
+            MDPriceLevel (1023): 2
+            MDUpdateAction (279): Change
+            MDEntryType (269): Offer
+    Message 2 of 2: TID 32 (MDIncrementalRefreshBook) v6
+        TransactTime (60): 02/05/2016 07:30:22.595256135 (1454679022595256135)
+        MatchEventIndicator (5799): LastImpliedMsg, EndOfEvent
+        NoMDEntries (268): 8
+        Entry 1
+            MDEntryPx (270): 475000000 (47.5)
+            MDEntrySize (271): 296
+            SecurityID (48): 817777
+            RptSeq (83): 1573080
+            NumberOfOrders (346): Null
+            MDPriceLevel (1023): 2
+            MDUpdateAction (279): Change
+            MDEntryType (269): ImpliedBid
+        Entry 2...
+```
 
 mdp_book_builder.py
 -------------------

--- a/scripts/mdp_decoder.py
+++ b/scripts/mdp_decoder.py
@@ -12,6 +12,7 @@ import binascii
 from sbedecoder import SBESchema
 from sbedecoder import SBEMessageFactory
 from sbedecoder import SBEParser
+import mdp_prettyprinter
 import gzip
 import dpkt
 
@@ -31,24 +32,37 @@ def handle_repeating_groups(group_container, msg_version, indent, skip_fields):
         handle_repeating_groups(group, msg_version, indent + ':', skip_fields=skip_fields)
 
 
-def parse_mdp3_packet(mdp_parser, ts, data, skip_fields, print_data):
+def parse_mdp3_packet(mdp_parser, ts, data, skip_fields, print_data, pretty):
     if print_data:
         print('data: {}'.format(binascii.b2a_hex(data)))
+
     timestamp = datetime.fromtimestamp(ts)
     # parse the packet header: http://www.cmegroup.com/confluence/display/EPICSANDBOX/MDP+3.0+-+Binary+Packet+Header
     sequence_number = unpack_from("<i", data, offset=0)[0]
     sending_time = unpack_from("<Q", data, offset=4)[0]
+
     print(':packet - timestamp: {} sequence_number: {} sending_time: {} '.format(
         timestamp, sequence_number, sending_time))
-    for mdp_message in mdp_parser.parse(data, offset=12):
-        message_fields = ''
-        for field in mdp_message.fields:
-            if field.since_version > mdp_message.version.value:  # field is later version than msg
-                continue
-            if field.name not in skip_fields:
-                message_fields += ' ' + str(field)
-        print('::{} - {}'.format(mdp_message, message_fields))
-        handle_repeating_groups(mdp_message, mdp_message.version.value, indent='::::', skip_fields=skip_fields)
+
+    if pretty:
+        # Two-passes on the parse so we can count the messages and print e.g. "Message 3 of 5"
+        #
+        # Cannot store messages from the iteration, as field objects get reused and overwritten
+        # on each round.
+        n = len(list(mdp_parser.parse(data, offset=12)))  # pass 1 to count the msgs in iterable
+
+        for i, mdp_message in enumerate(mdp_parser.parse(data, offset=12)):  # pass 2 to actually print
+            mdp_prettyprinter.pretty_print(mdp_message, i, n)
+    else:
+        for mdp_message in mdp_parser.parse(data, offset=12):
+            message_fields = ''
+            for field in mdp_message.fields:
+                if field.since_version > mdp_message.version.value:  # field is later version than msg
+                    continue
+                if field.name not in skip_fields:
+                    message_fields += ' ' + str(field)
+            print('::{} - {}'.format(mdp_message, message_fields))
+            handle_repeating_groups(mdp_message, mdp_message.version.value, indent='::::', skip_fields=skip_fields)
 
 
 def process_file(args, pcap_filename, print_data):
@@ -71,7 +85,7 @@ def process_file(args, pcap_filename, print_data):
                 if ip.p == dpkt.ip.IP_PROTO_UDP:
                     udp = ip.data
                     try:
-                        parse_mdp3_packet(mdp_parser, ts, udp.data, skip_fields, print_data)
+                        parse_mdp3_packet(mdp_parser, ts, udp.data, skip_fields, print_data, args.pretty)
                     except Exception as e:
                         print('Error parsing packet #{} - {}'.format(packet_number, e))
 
@@ -96,6 +110,9 @@ def process_command_line():
 
     parser.add_argument("--print-data", action='store_true',
         help="Print the data as an ascii hex string (default: %(default)s)")
+
+    parser.add_argument("--pretty", action='store_true',
+        help="Print the message with a pretty format")
 
     args = parser.parse_args()
 

--- a/scripts/mdp_prettyprinter.py
+++ b/scripts/mdp_prettyprinter.py
@@ -1,6 +1,4 @@
 
-import binascii
-import struct
 from datetime import datetime
 
 def mdp3time(t):

--- a/scripts/mdp_prettyprinter.py
+++ b/scripts/mdp_prettyprinter.py
@@ -1,0 +1,54 @@
+
+import binascii
+import struct
+from datetime import datetime
+
+def mdp3time(t):
+    dt = datetime.fromtimestamp(t // 1000000000)
+    s = dt.strftime('%m/%d/%Y %H:%M:%S')
+    s += '.' + str(int(t % 1000000000)).zfill(9)
+    return s
+
+def adjustField(field):
+    if field.semantic_type == 'UTCTimestamp':
+        return '{} ({})'.format(mdp3time(field.value), field.value)
+
+    # Use enum name rather than description, to match MC
+    if hasattr(field, 'enumerant'):
+        value = field.enumerant
+    else:
+        value = field.value
+
+    # Make prices match MC (no decimal)
+    if field.semantic_type == 'Price':
+        if value is not None:
+            value = '{} ({})'.format(str(int(float(value) * 10000000)), value)
+
+    value = '<Empty>' if value == '' else value
+    value = 'Null' if value is None else value
+    return value
+
+
+def pretty_print(msg, i, n):
+    print '    Message %d of %d: TID %d (%s) v%d' % (i + 1, n, msg.template_id.value, msg.name, msg.version.value)
+    for field in [x for x in msg.fields if x.original_name[0].isupper()]:
+        if field.since_version > msg.version.value: # field is later version than msg
+            continue
+        value = adjustField(field)
+        if field.id:
+            print '        %s (%s): %s' % (field.original_name, field.id, value)
+        else:
+            print '        %s: %s' % (field.original_name, value)
+    for group_container in msg.groups:
+        if group_container.since_version > msg.version.value:
+            continue
+        print '        %s (%d): %d' % (
+        group_container.original_name, group_container.id, group_container.num_groups)
+        for i_instance, group_instance in enumerate(group_container):
+            print '        Entry %d' % (i_instance + 1)
+            for field in group_instance.fields:
+                if field.since_version > msg.version.value:
+                    continue
+                value = adjustField(field)
+                print '            %s (%s): %s' % (field.original_name, field.id, value)
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="sbedecoder",
-    version="0.1.1",
+    version="0.1.2",
     author="TradeForecaster Global Markets, LLC",
     author_email="github@tradeforecaster.com",
     description=("Simple Bianry Encoding (SBE) decoder (handles CME MDP3 messages)"),


### PR DESCRIPTION
Modified mdp_decoder to correctly handle back-versioned streams using the recently added version support.

Added a --pretty option to mdp_decoder to use an alternate formatter for prettier output, like:

```
packet - timestamp: 2016-03-10 15:33:21.301819 sequence_number: 76643046 sending_time: 1454679022595400091 
    Message 1 of 2: TID 32 (MDIncrementalRefreshBook) v6
        TransactTime (60): 02/05/2016 07:30:22.595256135 (1454679022595256135)
        MatchEventIndicator (5799): LastQuoteMsg
        NoMDEntries (268): 1
        Entry 1
            MDEntryPx (270): 98890000000 (9889.0)
            MDEntrySize (271): 296
            SecurityID (48): 807004
            RptSeq (83): 14273794
            NumberOfOrders (346): 16
            MDPriceLevel (1023): 2
            MDUpdateAction (279): Change
            MDEntryType (269): Offer
    Message 2 of 2: TID 32 (MDIncrementalRefreshBook) v6
        TransactTime (60): 02/05/2016 07:30:22.595256135 (1454679022595256135)
        MatchEventIndicator (5799): LastImpliedMsg, EndOfEvent
        NoMDEntries (268): 8
        Entry 1
            MDEntryPx (270): 475000000 (47.5)
            MDEntrySize (271): 296
            SecurityID (48): 817777
            RptSeq (83): 1573080
            NumberOfOrders (346): Null
            MDPriceLevel (1023): 2
            MDUpdateAction (279): Change
            MDEntryType (269): ImpliedBid
        Entry 2...
 ```