### PR TITLE
Add SBE Defaults 

### DIFF
--- a/sbedecoder/__init__.py
+++ b/sbedecoder/__init__.py
@@ -1,3 +1,3 @@
 from schema import SBESchema
-from message import SBEMessageFactory
+from message import SBEMessageFactory, MDPMessageFactory
 from parser import SBEParser

--- a/sbedecoder/parser.py
+++ b/sbedecoder/parser.py
@@ -5,6 +5,6 @@ class SBEParser(object):
     def parse(self, message_buffer, offset=0):
         msg_offset = offset
         while msg_offset < len(message_buffer):
-            message = self.factory.build(message_buffer, msg_offset)
-            msg_offset += message.message_size.value
+            message, message_size = self.factory.build(message_buffer, msg_offset)
+            msg_offset += message_size
             yield message

--- a/scripts/mdp_decoder.py
+++ b/scripts/mdp_decoder.py
@@ -7,7 +7,7 @@ Parse a pcap file containing CME MDP3 market data based on a SBE xml schema file
 import sys
 import os.path
 from sbedecoder import SBESchema
-from sbedecoder import SBEMessageFactory
+from sbedecoder import MDPMessageFactory
 from sbedecoder import SBEParser
 import mdp.prettyprinter
 import mdp.secdef
@@ -77,7 +77,7 @@ def main(argv=None):
     # Read in the schema xml as a dictionary and construct the various schema objects
     mdp_schema = SBESchema()
     mdp_schema.parse(args.schema)
-    msg_factory = SBEMessageFactory(mdp_schema)
+    msg_factory = MDPMessageFactory(mdp_schema)
     mdp_parser = SBEParser(msg_factory)
 
     secdef = None


### PR DESCRIPTION
I found the project very useful (thank you!) and added the following for my own usage. I thought others might like these additions too... If there are any changes needed, please let me know!

- primitive types are added by default so you can just specify a `type="int32"` without having to specify another full type for primitives in the XML
- description attribute is optional as allowed by sbe standard
  - message types are also now based off name instead of description
- removed the `header_size` field that was automatically added in every message
  - this seems to be a cme sbe specific thing
  - i left the current functionality in place by default and you can just pass a an `include_message_size_header=False` parameter when call `SBESchema().parse()`, if you're like me and don't want that for your usage of sbe
- blockSize is optional, if not provided block_header will be automatically determined based on the length of the fields
- `SBEMessageFactory` was broken into a base class and `MDPMessageFactory` was added for working with cme MDP messages
  - this is related to the same header_size item that seems CME specific the original message factory was accounting for an extra 2 bytes when trying to get the templateId
  - since header_size was cme specific, the `SBEParser` was updated and expects the build method to return a tuple of (message, message_size)