### PR TITLE
Alternative method to allow dynamic header size

### DIFF
--- a/mdp/secdef.py
+++ b/mdp/secdef.py
@@ -7,8 +7,8 @@ class SecDef(object):
         self.info = {}
 
     def load(self, secdef_filename):
-        tag_regexp = re.compile('(?:^|\x01)(48|55)=(.*?)(?=\x01)')
-        depth_regexp = re.compile('1022=GBX\x01264=(\d+)')
+        tag_regexp = re.compile(r'(?:^|\x01)(48|55)=(.*?)(?=\x01)')
+        depth_regexp = re.compile(r'1022=GBX\x01264=(\d+)')
         with gzip.open(secdef_filename, 'rb') as f:
             for line in f:
                 line = line.decode('UTF-8')

--- a/sbedecoder/message.py
+++ b/sbedecoder/message.py
@@ -368,9 +368,10 @@ class MDPMessageFactory(SBEMessageFactory):
         super(MDPMessageFactory, self).__init__(schema)
 
     def build(self, msg_buffer, offset):
-        # Peek at the template id to figure out what class to build
-        # this looks past the starting 2 byte message_size header that is CME specific
-        # and the 2 byte BlockHeader that starts all SBE Messages
+        # Peek at the template id to figure out what class to build.
+        # This looks past the starting 2 byte MsgSize header that is CME specific
+        # and the 2 byte BlockLength that starts all SBE Messages:
+        #   https://www.cmegroup.com/confluence/display/EPICSANDBOX/MDP+3.0+-+Message+Header
         template_id = unpack_from('<H', msg_buffer, offset+4)[0]
         message_type = self.schema.get_message_type(template_id)
         message = message_type()

--- a/sbedecoder/schema.py
+++ b/sbedecoder/schema.py
@@ -345,12 +345,10 @@ class SBESchema(object):
         setattr(message_type, 'header_size', field_offset)
         return field_offset
 
-    def _add_fields(self, field_offset, entity, entity_type, endian, add_header_size=True, header_size=10):
+    def _add_fields(self, field_offset, entity, entity_type, endian, add_header_size=True):
         # Now run through the remaining types and update the fields
         for field_type in entity.get('fields', []):
-            field_type['offset'] = None
-            field = self._build_message_field(field_type, field_offset, header_size=header_size, endian=endian,
-                                              add_header_size=add_header_size)
+            field = self._build_message_field(field_type, field_offset, endian=endian, add_header_size=add_header_size)
             field_offset += field.field_length
             entity_type.fields.append(field)
             # make it an attribute too
@@ -415,8 +413,7 @@ class SBESchema(object):
     def _construct_body(self, message, field_offset, endian):
         message_id = int(message['id'])
         message_type = self.get_message_type(message_id)
-        self._add_fields(field_offset, message, message_type, endian, add_header_size=True,
-                         header_size=message_type.header_size)
+        self._add_fields(field_offset, message, message_type, endian, add_header_size=True)
         self._add_groups(message, message_type, endian)
 
     def parse(self, xml_file, message_tag="message", types_tag="types", endian='<'):


### PR DESCRIPTION
This reverts PR #42 in favor of an alternative implementation that doesn't break the build.  Basically, it gets the actual header size as stored in the `message_type`.  If the schema has `include_message_size_header`, the header size will include 2 bytes for the CME Groups' non-standard `MsgSize` field that they include in the header.
